### PR TITLE
fix: tk8s.conf 預設 KVER 指到不存在的 image tag

### DIFF
--- a/conf/tk8s.conf
+++ b/conf/tk8s.conf
@@ -2,7 +2,7 @@ export TKIND="K8S"
 export NTP="Internal"
 export PROXY=""
 export K8SCNI="canal"
-[ "$KVER" ==  "" ] && export KVER='1.35.0' 
+[ "$KVER" ==  "" ] && export KVER='1.35.5' 
 
 # Container Configuration
 export NID="172.22.0.0/24"


### PR DESCRIPTION
`conf/tk8s.conf` 預設 `KVER='1.35.0'`，但 `quay.io/cloudwalker/taroko` 沒有 `v1.35.0` 這個 tag——**以預設設定建叢集會在拉節點 image 時失敗**。改為 `1.35.5`（存在且為 kto 說明列出的版本）。

驗證：在乾淨的 Debian 13 VM 上，從全新 clone 以 `kto tk8s 1.35.5` 完整建成三節點叢集（control-plane + 2 workers 全 Ready，canal / metrics-server / local-path / tkadm / dkreg 全部正常）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)