### PR TITLE
feat: 教材掛載改為 WULIN_DIR 可設定；RuntimeClass 開箱可用

### DIFF
--- a/bin/kcn
+++ b/bin/kcn
@@ -10,6 +10,15 @@ export HDIR=~
 source ~/tk/conf/${cn}.conf
 ([ "$LCTN" == "" ] || [ "$TKIND" == "" ] || [ "$NTP" == "" ]) && echo "~/tk/conf/${cn}.conf error" && exit 1
 
+# 教材（wulin repo）的掛載來源，掛進每個節點的 /opt/wulin
+# 未設定 WULIN_DIR 時預設 ~/wulin；目錄不存在則建立空目錄並提示
+export WULIN_DIR="${WULIN_DIR:-$HOME/wulin}"
+if [ ! -d "$WULIN_DIR" ]; then
+   echo "WULIN_DIR ($WULIN_DIR) not found: labs unavailable"
+   echo "  git clone https://github.com/tarokolabs/wulin.git $WULIN_DIR"
+   mkdir -p "$WULIN_DIR"
+fi
+
 # install cni
 if [ ! -d ~/cni ]; then
    mkdir -p ~/cni
@@ -57,7 +66,7 @@ case "$NTP" in
          --volume /lib/modules:/lib/modules:ro \
          --volume ${controlVolume}:/var:suid,exec,dev,rbind \
          --volume /opt/zfs/${cn}:/opt/zfs \
-         --volume ${HDIR}/tk/wulin:/opt/wulin \
+         --volume ${WULIN_DIR}:/opt/wulin \
          --cgroupns=private \
          $IMG bash &>/tmp/${ctn}.out
          [ "$?" != "0" ] && echo "${ctn} container created error" && exit 1
@@ -90,7 +99,7 @@ case "$NTP" in
          --volume /lib/modules:/lib/modules:ro \
          --volume ${controlVolume}:/var:suid,exec,dev,rbind \
          --volume /opt/zfs/${cn}:/opt/zfs \
-         --volume ${HDIR}/tk/wulin:/opt/wulin \
+         --volume ${WULIN_DIR}:/opt/wulin \
          --cgroupns=private \
          $IMG bash &>/dev/null
          [ "$?" == "0" ] && echo -n "${ctn} container created"

--- a/bin/kto
+++ b/bin/kto
@@ -206,6 +206,10 @@ if [ "$TKIND" == "K8S" ]; then
          ${HDIR}/tk/bin/deploy-rc.sh &>/dev/null
          echo "gVisor & crun ok"
 
+         # 註冊對應的 RuntimeClass，讓 runtimeClassName: gvisor/crun 開箱可用
+         kubectl apply -f ${HDIR}/tk/bin/runtimeclass.yaml &>/dev/null
+         [ "$?" == "0" ] && echo "RuntimeClass gvisor & crun ok"
+
          # install Metrics Server
          [ -f /tmp/metrics.yaml ] && rm /tmp/metrics.yaml
          curl -sL https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml \

--- a/bin/runtimeclass.yaml
+++ b/bin/runtimeclass.yaml
@@ -1,0 +1,13 @@
+# 平台安裝的替代 container runtime 對應的 RuntimeClass
+# handler 名稱對應 containerd 設定（bin/containerd-config*.yaml）中註冊的 runtime
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: gvisor
+handler: runsc
+---
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: crun
+handler: crun

--- a/wulin/bin/system.sh
+++ b/wulin/bin/system.sh
@@ -70,6 +70,8 @@ if [ "$USER" == "bigred" ]; then
    sudo chmod u+s /usr/bin/newuidmap
    sudo chmod u+s /usr/bin/newgidmap
 
-   export PATH=/home/bigred/wulin/wk/dt/bin/:/home/bigred/wulin/wk/dip/bin/:$PATH
+   # 教材（wulin repo）掛載存在時才加入 PATH；未掛載時課程指令不可用但不報錯
+   [ -d /home/bigred/wulin/wk/dt/bin ]  && export PATH=/home/bigred/wulin/wk/dt/bin/:$PATH
+   [ -d /home/bigred/wulin/wk/dip/bin ] && export PATH=/home/bigred/wulin/wk/dip/bin/:$PATH
 fi
 


### PR DESCRIPTION
修復 #3（教材掛載靜默失效）與 #26（RuntimeClass 缺物件），兩案共用同一次叢集重建驗證。

## 改了什麼

| 檔案 | 變更 |
|---|---|
| `bin/kcn` | 節點的 `/opt/wulin` 掛載來源從硬寫的 `~/tk/wulin` 改為 **`${WULIN_DIR:-$HOME/wulin}`**（wulin repo 的 clone 位置）。目錄不存在時印出取得教材的提示並建立空目錄，平台功能不受影響。Internal 與 External 兩種模式都改 |
| `wulin/bin/system.sh` | 課程 PATH 加存在性防護——教材未掛載時不再把不存在的路徑塞進 PATH |
| `bin/runtimeclass.yaml`（新增） | `gvisor`→`runsc`、`crun`→`crun` 兩個 RuntimeClass |
| `bin/kto` | 安裝 gVisor/crun 後 apply 上述 manifest，輸出 `RuntimeClass gvisor & crun ok` |

## 驗證（實際叢集，乾淨 VM、本 branch 全新 clone）

- 叢集完整建成：`take office`、exit 0，三節點 Ready、平台元件全綠
- **#26**：`kubectl get runtimeclass` 開箱有 `gvisor`/`crun`；`runtimeClassName: gvisor` 的 Pod 內 `uname -r` = `4.19.0-gvisor`
- **#3**：`~/wulin`（教材 repo clone）自動被掛載——節點內與 **Pod 內**（經 hostPath）都看得到完整教材（`labs/` 的 dt/lkh/dip/devops/mt 全在）
- 邊界：`WULIN_DIR` 未設且 `~/wulin` 不存在 → 印出 clone 提示、建空目錄、叢集照常可建；自訂 `WULIN_DIR` 正確解析
- External 模式的程式變更與 Internal 相同，但未實測（測試環境用 Internal）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
