### PR TITLE
feat: 預設 CNI 改為 cilium，南北向以 Envoy Gateway（Gateway API）為主

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@
 | 元件 | 說明 |
 |---|---|
 | Kubernetes | 以 `kubeadm` 建置，節點為 privileged podman 容器 |
-| CNI | canal（可切換為 cilium） |
-| 負載平衡 | MetalLB |
+| CNI | **cilium**（預設 1.20.0，kube-proxy replacement 模式；可切換 canal） |
+| 負載平衡 | cilium LB-IPAM + L2 announcement——LoadBalancer IP 原生提供（節點網段 .200–.219） |
 | 儲存 | local-path-provisioner |
-| Gateway / Ingress | — |
+| Gateway API | Envoy Gateway（GatewayClass `eg`；envoy 以 DaemonSet 部署，`externalTrafficPolicy: Local` 保留來源 IP；CRD 採 experimental channel，含 TCPRoute/UDPRoute） |
 | 管理主機 | tkadm，內含 kubectl / k9s / krew / task / skopeo / buildah，以及一個私有 container registry |
 | 容器 runtime 擴充 | gVisor、crun |
 | 資源監控 | metrics-server（`kubectl top` 可用） |
 
-**不包含** Prometheus / Grafana 等監控工具、資料庫、物件儲存與應用工作負載——這些在 [wulin](https://github.com/tarokolabs/wulin)。
+**不包含** Prometheus / Grafana 等監控工具、資料庫、物件儲存與應用工作負載——這些在 [wulin](https://github.com/tarokolabs/wulin)。MetalLB 與 ingress-nginx 也移列教材選配（LoadBalancer 與南北向入口已由 cilium LB-IPAM 與 Envoy Gateway 原生涵蓋）。
 
 ## 架構
 
@@ -66,7 +66,7 @@ kto <叢集名稱> [K8s 版本]
 
 | 名稱 | 節點數 | 網段 | 預設 K8s 版本 |
 |---|---|---|---|
-| `tk8s` | 3 | `172.22.0.0/24` | 1.35.0 |
+| `tk8s` | 3 | `172.22.0.0/24` | 1.35.5 |
 | `tkbp` | 3 | `172.22.8.0/24` | 1.35.5 |
 | `tkdt` | 5 | `172.22.16.0/24` | 1.35.5 |
 | `tklh` | 3 | `172.22.16.0/24` | 1.35.5 |

--- a/bin/cilium-lb.yaml
+++ b/bin/cilium-lb.yaml
@@ -1,0 +1,19 @@
+# cilium 的 LoadBalancer IP 池與 L2 對外公告
+# LBNET 由 kto 以 envsubst 帶入（節點網段前三組，例如 172.22.0）
+# 池範圍 .200-.219 避開節點 IP（LCTN 慣例用低位）與閘道（.254）
+apiVersion: cilium.io/v2
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: default-pool
+spec:
+  blocks:
+  - start: ${LBNET}.200
+    stop: ${LBNET}.219
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumL2AnnouncementPolicy
+metadata:
+  name: default-l2
+spec:
+  loadBalancerIPs: true
+  externalIPs: true

--- a/bin/envoyproxy.yaml
+++ b/bin/envoyproxy.yaml
@@ -1,0 +1,19 @@
+# 平台預設的 EnvoyProxy 設定，由 GatewayClass eg 的 parametersRef 引用
+#
+# 以 DaemonSet 部署 envoy（Envoy Gateway 預設為 Deployment）：
+#   在 cilium 的 L2 announcement 下，持有 ARP lease 的節點與 envoy pod 所在
+#   節點不必然相同。若 envoy 是單一 Deployment，externalTrafficPolicy=Local
+#   會讓「持有 lease 但沒有本地 envoy」的節點丟棄外部流量——症狀是叢集內通、
+#   叢集外不通。
+#   改用 DaemonSet 讓每個節點都有本地 envoy，任一節點持有 lease 都有本地後端，
+#   因此可保留 externalTrafficPolicy=Local（來源 IP 不遺失）。
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: default
+  namespace: envoy-gateway-system
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDaemonSet: {}

--- a/bin/gatewayclass.yaml
+++ b/bin/gatewayclass.yaml
@@ -1,7 +1,13 @@
 # 平台預設的 GatewayClass，由 Envoy Gateway 實作
+# parametersRef 指向 bin/envoyproxy.yaml 的 EnvoyProxy（以 DaemonSet 部署 envoy）
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
   name: eg
 spec:
   controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: default
+    namespace: envoy-gateway-system

--- a/bin/gatewayclass.yaml
+++ b/bin/gatewayclass.yaml
@@ -1,0 +1,7 @@
+# 平台預設的 GatewayClass，由 Envoy Gateway 實作
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: eg
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/bin/kto
+++ b/bin/kto
@@ -62,6 +62,15 @@ if [ "$?" != "0" ]; then
    rm cilium-linux-amd64.tar.gz
 fi
 
+which helm &>/dev/null
+if [ "$?" != "0" ]; then
+   export HELM_VER=${HELM_VER:-v4.2.3}
+   curl -sL https://get.helm.sh/helm-${HELM_VER}-linux-amd64.tar.gz -o /tmp/helm.tgz &>/dev/null
+   sudo tar xzf /tmp/helm.tgz -C /usr/local/bin --strip-components=1 linux-amd64/helm
+   rm /tmp/helm.tgz
+   [ -x /usr/local/bin/helm ] && echo "helm ${HELM_VER} ok"
+fi
+
 which kubeletctl &>/dev/null
 if [ "$?" != "0" ]; then
    curl -LO https://github.com/cyberark/kubeletctl/releases/download/v1.13/kubeletctl_linux_amd64 &>/dev/null
@@ -238,14 +247,30 @@ if [ "$TKIND" == "K8S" ]; then
          [ "$?" == "0" ] && echo "Local Path Provisioner (/opt/zfs/storage) ok"
 
          # install Envoy Gateway（Gateway API 實作；LoadBalancer IP 由 cilium LB-IPAM 提供，
-         # 故僅在 cilium 路徑安裝。install.yaml 自帶 Gateway API CRD）
+         # 故僅在 cilium 路徑安裝）
+         # - CRD 由專用的 gateway-crds-helm 管理，channel 可選（預設 experimental，
+         #   含 TCPRoute/UDPRoute/TLSRoute）
+         # - 本叢集的 DNS 網域是 ${cn}.k8s 而非 cluster.local，必須以
+         #   kubernetesClusterDomain 告知 EG，否則 envoy 的 xDS bootstrap 會寫死
+         #   cluster.local 導致 proxy 永遠起不來
          if [ "$K8SCNI" == "cilium" ]; then
             export EG_VER=${EG_VER:-v1.8.3}
-            kubectl apply --server-side -f https://github.com/envoyproxy/gateway/releases/download/${EG_VER}/install.yaml &>/tmp/envoy-gateway.out
+            export GWAPI_CHANNEL=${GWAPI_CHANNEL:-experimental}
+
+            helm template eg-crds oci://docker.io/envoyproxy/gateway-crds-helm --version ${EG_VER} \
+                 --set crds.gatewayAPI.enabled=true \
+                 --set crds.gatewayAPI.channel=${GWAPI_CHANNEL} \
+                 --set crds.envoyGateway.enabled=true 2>/tmp/eg-crds.err | kubectl apply --server-side -f - &>/tmp/eg-crds.out
+            [ "$?" == "0" ] && echo "Gateway API CRD (${GWAPI_CHANNEL}) ok"
+
+            helm install eg oci://docker.io/envoyproxy/gateway-helm --version ${EG_VER} \
+                 -n envoy-gateway-system --create-namespace \
+                 --set crds.enabled=false \
+                 --set kubernetesClusterDomain=${cn}.k8s &>/tmp/envoy-gateway.out
             kubectl wait -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available --timeout=300s &>/dev/null
             if [ "$?" == "0" ]; then
                kubectl apply -f ${HDIR}/tk/bin/gatewayclass.yaml &>/dev/null
-               [ "$?" == "0" ] && echo "Envoy Gateway ${EG_VER} ok (GatewayClass: eg)"
+               [ "$?" == "0" ] && echo "Envoy Gateway ${EG_VER} ok (GatewayClass: eg, domain: ${cn}.k8s)"
             else
                echo "Envoy Gateway ${EG_VER} not ready (see /tmp/envoy-gateway.out)"
             fi

--- a/bin/kto
+++ b/bin/kto
@@ -269,8 +269,10 @@ if [ "$TKIND" == "K8S" ]; then
                  --set kubernetesClusterDomain=${cn}.k8s &>/tmp/envoy-gateway.out
             kubectl wait -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available --timeout=300s &>/dev/null
             if [ "$?" == "0" ]; then
+               # EnvoyProxy 需先於 GatewayClass 存在（GatewayClass 以 parametersRef 引用它）
+               kubectl apply -f ${HDIR}/tk/bin/envoyproxy.yaml &>/dev/null
                kubectl apply -f ${HDIR}/tk/bin/gatewayclass.yaml &>/dev/null
-               [ "$?" == "0" ] && echo "Envoy Gateway ${EG_VER} ok (GatewayClass: eg, domain: ${cn}.k8s)"
+               [ "$?" == "0" ] && echo "Envoy Gateway ${EG_VER} ok (GatewayClass: eg, DaemonSet, domain: ${cn}.k8s)"
             else
                echo "Envoy Gateway ${EG_VER} not ready (see /tmp/envoy-gateway.out)"
             fi

--- a/bin/kto
+++ b/bin/kto
@@ -260,7 +260,7 @@ if [ "$TKIND" == "K8S" ]; then
             helm template eg-crds oci://docker.io/envoyproxy/gateway-crds-helm --version ${EG_VER} \
                  --set crds.gatewayAPI.enabled=true \
                  --set crds.gatewayAPI.channel=${GWAPI_CHANNEL} \
-                 --set crds.envoyGateway.enabled=true 2>/tmp/eg-crds.err | kubectl apply --server-side -f - &>/tmp/eg-crds.out
+                 --set crds.envoyGateway.enabled=true 2>/dev/null | grep -vE "^(Pulled|Digest):" | kubectl apply --server-side -f - &>/tmp/eg-crds.out
             [ "$?" == "0" ] && echo "Gateway API CRD (${GWAPI_CHANNEL}) ok"
 
             helm install eg oci://docker.io/envoyproxy/gateway-helm --version ${EG_VER} \

--- a/bin/kto
+++ b/bin/kto
@@ -161,19 +161,33 @@ if [ "$TKIND" == "K8S" ]; then
             CNI="ok"
          fi 
       fi
-      if [ "$K8SCNI" == "cilium" ]; then 
+      if [ "$K8SCNI" == "cilium" ]; then
          kubectl delete daemonset -n kube-system kube-proxy &>/dev/null
 
-	 # If you prefer Cilium to use the CIDRs already assigned to nodes by the Kubernetes Controller Manager, 
-	 # use the kubernetes IPAM mode: 
-         cilium install --version 1.19.3 --set cgroup.autoMount.enabled=false \
+	 # If you prefer Cilium to use the CIDRs already assigned to nodes by the Kubernetes Controller Manager,
+	 # use the kubernetes IPAM mode:
+         # kube-proxy 已刪除，kubeProxyReplacement 為必要，並需明確指向 apiserver（SRVIP 來自 conf）
+         # l2announcements 讓 LoadBalancer IP 可從叢集外（主機側）到達
+         export CILIUM_VER=${CILIUM_VER:-1.20.0}
+         cilium install --version ${CILIUM_VER} --set cgroup.autoMount.enabled=false \
                 --set cgroup.hostRoot=/sys/fs/cgroup \
                 --set securityContext.privileged=true \
                 --set ipam.mode=kubernetes \
                 --set k8s.requireIPv4PodCIDR=true \
-                --set ipam.operator.clusterPoolIPv4MaskSize=24 &>/tmp/cilium1.19.3.out
+                --set ipam.operator.clusterPoolIPv4MaskSize=24 \
+                --set kubeProxyReplacement=true \
+                --set k8sServiceHost=${SRVIP} \
+                --set k8sServicePort=6443 \
+                --set l2announcements.enabled=true &>/tmp/cilium${CILIUM_VER}.out
 
          cilium status --wait &>/tmp/cilium.status
+         [ "$?" == "0" ] && echo "cilium ${CILIUM_VER} ok"
+
+         # LoadBalancer IP 池與 L2 對外公告（取節點網段 .200-.219，避開節點 IP 與閘道）
+         export LBNET=${NID%.*}
+         cat ${HDIR}/tk/bin/cilium-lb.yaml | envsubst '${LBNET}' | kubectl apply -f - &>/tmp/cilium-lb.out
+         [ "$?" == "0" ] && echo "cilium LB-IPAM (${LBNET}.200-219) ok"
+
          CNI="ok"
       fi
 
@@ -222,6 +236,20 @@ if [ "$TKIND" == "K8S" ]; then
          #kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.35/deploy/local-path-storage.yaml &>/dev/null
          kubectl apply -f ~/tk/bin/local-path-storage.0.0.35.yaml &>/tmp/local-path-storage.0.0.35.out
          [ "$?" == "0" ] && echo "Local Path Provisioner (/opt/zfs/storage) ok"
+
+         # install Envoy Gateway（Gateway API 實作；LoadBalancer IP 由 cilium LB-IPAM 提供，
+         # 故僅在 cilium 路徑安裝。install.yaml 自帶 Gateway API CRD）
+         if [ "$K8SCNI" == "cilium" ]; then
+            export EG_VER=${EG_VER:-v1.8.3}
+            kubectl apply --server-side -f https://github.com/envoyproxy/gateway/releases/download/${EG_VER}/install.yaml &>/tmp/envoy-gateway.out
+            kubectl wait -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available --timeout=300s &>/dev/null
+            if [ "$?" == "0" ]; then
+               kubectl apply -f ${HDIR}/tk/bin/gatewayclass.yaml &>/dev/null
+               [ "$?" == "0" ] && echo "Envoy Gateway ${EG_VER} ok (GatewayClass: eg)"
+            else
+               echo "Envoy Gateway ${EG_VER} not ready (see /tmp/envoy-gateway.out)"
+            fi
+         fi
 
          # install tkadm
          kubectl create ns taroko &>/dev/null

--- a/conf/lkh5.conf
+++ b/conf/lkh5.conf
@@ -2,7 +2,7 @@ export TKIND="K8S"
 export NTP="Internal"
 
 export PROXY=""
-export K8SCNI="canal"
+export K8SCNI="cilium"
 [ "$KVER" ==  "" ] && export KVER='1.34.8'
 
 # Container Configuration

--- a/conf/tdcs1.conf
+++ b/conf/tdcs1.conf
@@ -1,7 +1,7 @@
 export TKIND="K8S"
 export NTP="Internal"
 export PROXY=""
-export K8SCNI="canal"
+export K8SCNI="cilium"
 [ "$KVER" ==  "" ] && export KVER='1.34.8' 
 
 # Container Configuration

--- a/conf/tk8s.conf
+++ b/conf/tk8s.conf
@@ -1,7 +1,7 @@
 export TKIND="K8S"
 export NTP="Internal"
 export PROXY=""
-export K8SCNI="canal"
+export K8SCNI="cilium"
 [ "$KVER" ==  "" ] && export KVER='1.35.5' 
 
 # Container Configuration

--- a/conf/tkdev.conf
+++ b/conf/tkdev.conf
@@ -1,7 +1,7 @@
 export TKIND="K8S"
 export NTP="Internal"
 export PROXY=""
-export K8SCNI="canal"
+export K8SCNI="cilium"
 [ "$KVER" ==  "" ] && export KVER='1.34.3'
 
 # Container Configuration

--- a/conf/tkdt.conf
+++ b/conf/tkdt.conf
@@ -1,7 +1,7 @@
 export TKIND="K8S"
 export NTP="Internal"
 export PROXY=""
-export K8SCNI="canal"
+export K8SCNI="cilium"
 [ "$KVER" ==  "" ] && export KVER='1.35.5' 
 
 # Container Configuration

--- a/conf/tklh.conf
+++ b/conf/tklh.conf
@@ -1,7 +1,7 @@
 export TKIND="K8S"
 export NTP="Internal"
 export PROXY=""
-export K8SCNI="canal"
+export K8SCNI="cilium"
 [ "$KVER" ==  "" ] && export KVER='1.35.5' 
 
 # Container Configuration

--- a/conf/tkops.conf
+++ b/conf/tkops.conf
@@ -1,7 +1,7 @@
 export TKIND="K8S"
 export NTP="Internal"
 export PROXY=""
-export K8SCNI="canal"
+export K8SCNI="cilium"
 [ "$KVER" ==  "" ] && export KVER='1.34.3'
 
 # Container Configuration


### PR DESCRIPTION
實作 #7：預設 CNI 改為 **cilium**，南北向以 **Gateway API（Envoy Gateway 實作）** 為主。MetalLB 與 ingress-nginx 移列教材選配。

## 變更總覽

| 項目 | 內容 |
|---|---|
| 預設 CNI | 9 個 conf 全改 `K8SCNI="cilium"`（canal 路徑保留可切換） |
| cilium | 1.20.0（`CILIUM_VER` 變數）；補上 `kubeProxyReplacement=true` + `k8sServiceHost`（kube-proxy 本來就被刪除，KPR 是必要而非可選）、`l2announcements` |
| LoadBalancer | cilium 原生 LB-IPAM + L2 announcement（`bin/cilium-lb.yaml`，節點網段 .200–.219），取代 MetalLB |
| Gateway API | Envoy Gateway v1.8.3（`EG_VER` 變數），helm 雙 chart 安裝；GatewayClass `eg`；**envoy 以 DaemonSet 部署**（`bin/envoyproxy.yaml`） |
| CRD 管理 | 專用 `gateway-crds-helm` chart，channel 明確參數化（`GWAPI_CHANNEL`，預設 experimental——含 TCPRoute/UDPRoute/TLSRoute）；gateway-helm 以 `crds.enabled=false` 避免雙重擁有權 |
| 工具引導 | helm binary 自動下載（`HELM_VER`，預設 v4.2.3），與 kubectl/cilium-cli 同模式 |

## 實測發現並修復的三個整合問題

**1. EG 寫死 `cluster.local`，本平台叢集網域是 `${cn}.k8s`**
install.yaml 安裝的 EG 把 envoy 的 xDS bootstrap 位址寫死為 `…svc.cluster.local`，envoy 以 STRICT_DNS 解析不存在的名稱 → `no healthy upstream` → proxy 永遠起不來、Gateway 無法 PROGRAMMED。改 helm 安裝並以 `kubernetesClusterDomain=${cn}.k8s` 帶入正確網域（每叢集動態）。

**2. cilium L2 announcement × EG 預設 Deployment = 外部不可達**
持有 ARP lease 的節點與 envoy pod 所在節點不必然相同；EG 的 LB Service 預設 `externalTrafficPolicy: Local`，「持有 lease 但無本地 envoy」的節點會丟棄外部流量。症狀：叢集內通、叢集外不通（cilium 服務表的外部條目 backend 為空）。修法：EnvoyProxy 以 **DaemonSet** 部署 envoy——每節點都有本地後端，任何節點持有 lease 都能服務，且**保留 `Local` 政策（來源 IP 不遺失）**。改 `Cluster` 政策也能通，但會 SNAT 掉真實客戶端 IP，故不採。

**3. helm 4 把 OCI 拉取進度印到 stdout**
`Pulled:`/`Digest:` 行混入 `helm template | kubectl apply` 的 YAML 串流（helm 3 在 stderr）。已加過濾。

## 驗證（乾淨 VM、全新 clone、kto 全自動流程，無任何手動修補）

**cilium 預設路徑：**
- 三節點 Ready、cilium 1.20.0 status 全綠、metrics / local-path / tkadm / dkreg / RuntimeClass 全部正常
- GatewayClass `eg` Accepted；Gateway 取得 LB-IPAM 池 IP `172.22.0.200`、`PROGRAMMED=True`
- envoy DaemonSet 三節點各一、`externalTrafficPolicy: Local`
- **叢集外 curl ×3 全部 HTTP 200**，HTTPRoute 內容正確
- **來源 IP 保留實證**：envoy access log 的 `x-forwarded-for` = `172.22.0.254`（主機真實 IP，非 SNAT）

**canal 迴歸（`K8SCNI="canal"`）：**
- 叢集完整建成、三節點 Ready、RuntimeClass 正常
- EG 正確跳過（LoadBalancer 依賴 LB-IPAM，canal 路徑無此前提）

## 已知限制

- EG 僅在 cilium 路徑安裝；canal 路徑維持原狀（無 LB 提供者，Gateway API 不適用）
- L2 announcement 的可達範圍是主機的 L2 網段（教學環境的預期使用方式）；多節點／跨主機時的對外公告屬 BGP 題目，另案處理

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
