### PR TITLE
feat: tkadm 的 htpasswd 與 .gitconfig 改為建置時生成

### DIFF
--- a/wulin/images/tkadm/Containerfile
+++ b/wulin/images/tkadm/Containerfile
@@ -1,18 +1,32 @@
 ARG VER=00.00
 FROM quay.io/cloudwalker/alp.base
 
-# containers.conf  - The container engine (podman, buildah) configuration file specifies 
+# 管理帳號與私有 registry（dkreg）的認證。預設為教學帳密，正式環境以
+# build-arg 覆寫：
+#   podman build --build-arg REG_USER=admin --build-arg REG_PASS=<secret> ...
+ARG REG_USER=bigred
+ARG REG_PASS=bigred
+ARG GIT_NAME=bigred
+ARG GIT_EMAIL=bigred@taroko.k8s
+
+# containers.conf  - The container engine (podman, buildah) configuration file specifies
 # default configuration options and command-line flags for container engines.
 COPY "containers.conf" "/etc/containers/"
 COPY web /opt
-COPY goweb .gitconfig htpasswd config.yaml /var/tmp
+COPY goweb config.yaml /var/tmp
 RUN  mkdir -p /etc/skel/.ssh
-COPY ssh/* /etc/skel/.ssh/
 
 RUN apk update && apk upgrade && mkdir -p /lib/modules && mkdir -p /opt/www && \
     mv /opt/index.html /opt/www/ && mv /opt/cgi/ /opt/www/ && \
     apk add --no-cache openssh-server postgresql-client openrc tzdata shellcheck fuse-overlayfs podman \
-    skopeo buildah k9s openssl mariadb-connector-c && \
+    skopeo buildah k9s openssl mariadb-connector-c apache2-utils && \
+
+    # dkreg registry 認證檔：以 htpasswd 於建置時生成（bcrypt，cost 12）。
+    # dkreg manifest 從 /var/tmp/htpasswd 取用（見 wulin/wk/tkadm/tkadm-dkreg.yaml）
+    htpasswd -Bbn -C 12 "${REG_USER}" "${REG_PASS}" > /var/tmp/htpasswd && \
+
+    # git 身分：於建置時生成（原為排除在版控外的 .gitconfig）
+    printf '[user]\n\tname = %s\n\temail = %s\n[core]\n\teditor = nano\n' "${GIT_NAME}" "${GIT_EMAIL}" > /var/tmp/.gitconfig && \
 
     # 設定時區
     cp /usr/share/zoneinfo/Asia/Taipei /etc/localtime && \


### PR DESCRIPTION
實作 #9：dkreg registry 的認證檔不再依賴版控外的檔案，tkadm image 恢復可從全新 clone 建置。

## 背景

原 Containerfile `COPY` 的三個檔案（`htpasswd`、`.gitconfig`、`ssh/`）都在版控排除清單上——**tkadm image 從乾淨 repo 建置必然失敗**。

## 變更

| 項目 | 做法 |
|---|---|
| `htpasswd`（dkreg 認證） | 建置時以 `htpasswd -Bbn -C 12` 生成——bcrypt cost 從原檔的 5 升到 **12**。帳密走 build-arg `REG_USER`/`REG_PASS`，**預設 `bigred:bigred`**（教學環境行為不變、叢集內十餘處 `curl -u` 客戶端不需修改），正式環境以 build-arg 覆寫 |
| `.gitconfig` | 建置時以 printf 生成（`GIT_NAME`/`GIT_EMAIL` build-arg） |
| `COPY ssh/*` | 移除——SSH 金鑰的環境注入屬 #10 的設計範圍，本次先解除 build 依賴（`/etc/skel/.ssh` 維持空目錄，密碼登入不受影響） |

dkreg manifest 的取用介面（`/var/tmp/htpasswd`）不變。

## 驗證（沙箱實測）

- ✅ tkadm image 從全新 clone 建置成功（改動前必然失敗）
- ✅ 生成格式 `$2y$12$…`（bcrypt cost 12）
- ✅ `htpasswd -vb` 驗證預設帳密正確
- ✅ 自訂 build-arg（`admin:s3cret`）覆寫生效
- ✅ **端到端**：以 registry:2 + 相同的 `REGISTRY_AUTH` 環境變數（同 dkreg manifest）起真實 registry——`podman login` 正確密碼 **Login Succeeded**、錯誤密碼被拒
- ✅ `.gitconfig` 內容正確生成

## 備註

- 預設弱密碼是**刻意的教學預設**（安全審查已標注）：教學帳密的全面收斂由 #15 統籌，本次的改善是密碼不再進版控、cost 提升、可覆寫
- 執行中叢集拉的是 quay 上的預建 alp.tkadm，本 PR 只改建置路徑；重新發佈 image 屬 #20（GHCR）範圍

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)