### PR TITLE
feat: GitHub Release 與 image 發佈自動化（#13）

### DIFF
--- a/.github/workflows/node-images.yml
+++ b/.github/workflows/node-images.yml
@@ -1,0 +1,31 @@
+# 臨時補建節點 image（不發 Release）：K8s 出新 patch 版而平台無需發版時，
+# 手動觸發建置指定版本的 node/crio 與 node/containerd。
+# 前提：docker.io/kindest/node 已發佈對應版本 tag。
+name: node-images
+
+on:
+  workflow_dispatch:
+    inputs:
+      k8s_versions:
+        description: "K8s 版本（空白分隔，例：1.36.2 1.35.6）"
+        required: true
+        type: string
+
+permissions:
+  packages: write
+
+jobs:
+  node:
+    runs-on: ubuntu-latest
+    env:
+      K8S_VERSIONS: ${{ inputs.k8s_versions }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: 驗證輸入格式
+        run: |
+          echo "$K8S_VERSIONS" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+( [0-9]+\.[0-9]+\.[0-9]+)*$' \
+            || { echo "版本格式錯誤：$K8S_VERSIONS"; exit 1; }
+      - name: 登入 GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: 建置並推送節點 image
+        run: TK="$GITHUB_WORKSPACE" SUDO="" bin/build-images.sh node $K8S_VERSIONS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+# 發佈流程（#13）：推上 v* tag 即觸發
+#   1. 建置節點 image 矩陣（tag = K8s 版本）推送 GHCR——平台只發佈節點 image，
+#      叢集內 image（toolbox/admin 等）屬教材，由 wulin repo 發佈
+#   2. 彙整 digest，生成 Release notes（image 對照表即相容性契約）
+#   3. 建立 GitHub Release（安裝用的 source archive 由 GitHub 自動附上）
+# 首次設定：node/crio 與 node/containerd 兩個 package 的
+# Manage Actions access 需把本 repo 加為 Write，GITHUB_TOKEN 才推得動。
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  node:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        k8s: ["1.34.3", "1.34.8", "1.35.5", "1.36.1"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: 登入 GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: 建置並推送節點 image（兩個 runtime 變體）
+        run: TK="$GITHUB_WORKSPACE" SUDO="" DIGEST_DIR="$GITHUB_WORKSPACE/digests" bin/build-images.sh node "${{ matrix.k8s }}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests-node-${{ matrix.k8s }}
+          path: digests/
+
+  release:
+    needs: [node]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: digests-*
+          merge-multiple: true
+          path: digests
+      - name: 生成 Release notes
+        run: |
+          CILIUM=$(grep -oE 'CILIUM_VER:-[0-9.]+' bin/kto | head -1 | cut -d- -f2)
+          EG=$(grep -oE 'EG_VER:-v[0-9.]+' bin/kto | head -1 | cut -d- -f2)
+          {
+            echo "## 安裝"
+            echo
+            echo '```bash'
+            echo "git clone --branch $GITHUB_REF_NAME https://github.com/tarokolabs/tk8s.git ~/tk"
+            echo '```'
+            echo
+            echo "需求與使用方式見 [README](https://github.com/tarokolabs/tk8s/blob/$GITHUB_REF_NAME/README.md)。"
+            echo
+            echo "## 本版 image 對照表"
+            echo
+            echo "以下節點 image 由本 tag 的配方於 CI 建置（tag 對應 K8s 版本；以 digest 引用可完全固定內容）。叢集內 image（toolbox、admin 等）屬教材範疇，由 [wulin](https://github.com/tarokolabs/wulin) 發佈。"
+            echo
+            echo "| image | digest |"
+            echo "|---|---|"
+            sort digests/*.digest | awk '{printf "| `%s` | `%s` |\n", $1, $2}'
+            echo
+            echo "## 平台元件"
+            echo
+            echo "| 元件 | 版本 |"
+            echo "|---|---|"
+            echo "| Kubernetes（kubeadm）| 1.31–1.36（節點 image 提供 1.34.3 / 1.34.8 / 1.35.5 / 1.36.1）|"
+            echo "| Container runtime | CRI-O（對齊 K8s minor）；可切換 containerd |"
+            echo "| CNI | cilium ${CILIUM}（kube-proxy replacement + LB-IPAM/L2）|"
+            echo "| Gateway API | Envoy Gateway ${EG}（DaemonSet、experimental channel CRD）|"
+            echo "| 儲存 | local-path-provisioner |"
+          } > /tmp/notes.md
+          cat /tmp/notes.md
+      - name: 建立 Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" --title "tk8s $GITHUB_REF_NAME" --notes-file /tmp/notes.md

--- a/bin/build-images.sh
+++ b/bin/build-images.sh
@@ -5,24 +5,33 @@
 #   build-images.sh node <K8s版本>...     # 每個版本建 node/crio 與 node/containerd
 # （toolbox/admin 等叢集內 image 屬教材範疇，見 wulin repo 的 bin/build-images.sh）
 #
+# 環境變數：
+#   TK        repo 根目錄（預設 ~/tk；CI 設為 checkout 路徑）
+#   SUDO      前綴指令（預設 sudo；rootless podman 環境設為空字串）
+#   DIGEST_DIR 若設定，將各 image 的 digest 寫入該目錄（供 CI 彙整 release notes）
+#
 # 推送前需先登入：podman login ghcr.io
 # 命名規則見 https://github.com/tarokolabs/tk8s/issues/20
 
 REG="ghcr.io/tarokolabs/tk8s"
 LABELS="--label=org.opencontainers.image.source=https://github.com/tarokolabs/tk8s \
         --label=org.opencontainers.image.licenses=GPL-2.0"
-TK=~/tk
+TK="${TK:-$HOME/tk}"
+SUDO="${SUDO-sudo}"
 
 build_push() {  # <name:tag> <context 目錄> [額外 build 參數...]
-   local ref="${REG}/${1}" dir="${TK}/${2}" log="/tmp/build-$(echo ${1} | tr '/:' '--').out"
+   local ref="${REG}/${1}" dir="${TK}/${2}" safe="$(echo ${1} | tr '/:' '--')"
+   local log="/tmp/build-${safe}.out"
    shift 2
    echo "building ${ref}"
-   sudo podman build --format=docker --no-cache --force-rm ${LABELS} "$@" \
+   ${SUDO} podman build --format=docker --no-cache --force-rm ${LABELS} "$@" \
         -t "${ref}" "${dir}" &>"${log}"
-   [ "$?" != "0" ] && echo "  build failed（見 ${log}）" && exit 1
-   sudo podman push --digestfile "${log}.digest" "${ref}" &>/dev/null
+   [ "$?" != "0" ] && echo "  build failed（見 ${log}）" && tail -5 "${log}" && exit 1
+   ${SUDO} podman push --digestfile "${log}.digest" "${ref}" &>/dev/null
    [ "$?" != "0" ] && echo "  push failed（先 podman login ghcr.io）" && exit 1
    echo "  pushed ${ref}  $(cat ${log}.digest)"
+   [ -n "${DIGEST_DIR}" ] && mkdir -p "${DIGEST_DIR}" && \
+      echo "${ref}  $(cat ${log}.digest)" > "${DIGEST_DIR}/${safe}.digest"
 }
 
 case "$1" in


### PR DESCRIPTION
接替 #38（stacked base 分支刪除時被 GitHub 連帶關閉，內容一致、已 rebase 到 main）。關閉 #13。

## 發佈流程

推上 `v*` tag（CalVer）即自動：

1. **節點矩陣建置**：`node/crio` + `node/containerd` × 4 個 K8s 版本（tag = K8s 版本），`GITHUB_TOKEN` 推 GHCR。每次發版重建以刷新 OS 套件與 CRI-O patch。叢集內 image（toolbox/admin 等）屬教材，由 wulin 發佈，不在本流程
2. **Release notes 自動生成**：節點 image digest 對照表（相容性契約——node tag 跟著 K8s 版本走但內容隨配方演進，digest 表記錄「本版平台驗證的是哪個 digest」）＋平台元件版本表（cilium/EG 版本自 `bin/kto` 現抓）
3. **建立 Release**：發佈物即 GitHub 自動附的 source archive（安裝 = `git clone`）

tag 語意：**平台快照＋相容性契約的錨點**——平台有實質變更才發，不定期。

## 節點 image 的更新路徑

- 新增 K8s 版本支援：隨該版本的 PR 一併更新 matrix（可稽核）
- K8s 出 patch、平台無變更：手動觸發 `node-images` workflow 補建（含輸入驗證），不發版

## 合併後一次性設定

`tk8s/node/crio`、`tk8s/node/containerd` 兩個 package 的 **Manage Actions access** 加本 repo 為 **Write**。完成後推 `v2026.8.0` 即首次自動發佈。

🤖 Generated with [Claude Code](https://claude.com/claude-code)