### PR TITLE
fix: build-images.sh 未設 DIGEST_DIR 時 exit code 為 1

### DIFF
--- a/bin/build-images.sh
+++ b/bin/build-images.sh
@@ -30,8 +30,10 @@ build_push() {  # <name:tag> <context 目錄> [額外 build 參數...]
    ${SUDO} podman push --digestfile "${log}.digest" "${ref}" &>/dev/null
    [ "$?" != "0" ] && echo "  push failed（先 podman login ghcr.io）" && exit 1
    echo "  pushed ${ref}  $(cat ${log}.digest)"
-   [ -n "${DIGEST_DIR}" ] && mkdir -p "${DIGEST_DIR}" && \
+   if [ -n "${DIGEST_DIR}" ]; then
+      mkdir -p "${DIGEST_DIR}"
       echo "${ref}  $(cat ${log}.digest)" > "${DIGEST_DIR}/${safe}.digest"
+   fi
 }
 
 case "$1" in


### PR DESCRIPTION
`build_push` 末行的 `[ -n "${DIGEST_DIR}" ] && …` 在 `DIGEST_DIR` 未設定時回傳 1，成為腳本結束碼——`node-images` workflow 因此在**全部推送成功後**仍標記失敗（run 30782882862：兩顆 image 都推上去了，最後 exit 1）。改用 `if` 區塊。

該 run 同時證實：`GITHUB_TOKEN` 對兩個 node package 的推送權限開箱即用，先前 PR #40 說明中的「一次性 Actions access 設定」實際上不需要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)