### PR TITLE
docs: 授權變體宣告為 GPL-2.0-or-later（#16）

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,4 +109,4 @@ git log --all -- '技術文件'
 
 ## 授權
 
-GPL-2.0，見 [LICENSE](LICENSE)。
+本專案採 **GPL-2.0-or-later**（GNU GPL v2，或依你的選擇任何更新版本），見 [LICENSE](LICENSE)。

--- a/bin/build-images.sh
+++ b/bin/build-images.sh
@@ -15,7 +15,7 @@
 
 REG="ghcr.io/tarokolabs/tk8s"
 LABELS="--label=org.opencontainers.image.source=https://github.com/tarokolabs/tk8s \
-        --label=org.opencontainers.image.licenses=GPL-2.0"
+        --label=org.opencontainers.image.licenses=GPL-2.0-or-later"
 TK="${TK:-$HOME/tk}"
 SUDO="${SUDO-sudo}"
 


### PR DESCRIPTION
關閉 #16。團隊決議：**GPL-2.0-or-later**。

- 理由：GPL-3.0 與 Apache-2.0 相容，保留與 K8s 生態合併程式碼的可能（#20 的 kind base 長期選項是已具名的使用情境）；only 則永久排除此路徑
- 現狀（未宣告）依 GPL 第 9 條實質上已是接受者可自選版本——本 PR 將其變成明確選擇
- README 宣告 + OCI label 更新（`GPL-2.0` 為已棄用 SPDX 識別碼）；已發佈 image 的 label 於下次重建更新
- wulin 對應 PR 同步宣告

🤖 Generated with [Claude Code](https://claude.com/claude-code)