### PR TITLE
fix: conf 的 K8SCRI 尊重環境變數覆寫

### DIFF
--- a/conf/lkh5.conf
+++ b/conf/lkh5.conf
@@ -9,7 +9,7 @@ export K8SCNI="cilium"
 export NID="172.22.160.0/24"
 export NGW="172.22.160.254"
 # Container runtime：crio（預設）或 containerd
-export K8SCRI="crio"
+export K8SCRI="${K8SCRI:-crio}"
 # 節點 image：自 GHCR 拉取；離線或該版本未發佈時 kcn 會以同名配方本地建置
 export IMG="ghcr.io/tarokolabs/tk8s/node/${K8SCRI}:v${KVER}"
 export LCTN="172.22.160.1:lkh5-control-plane:4G:8 \

--- a/conf/tdcs1.conf
+++ b/conf/tdcs1.conf
@@ -8,7 +8,7 @@ export K8SCNI="cilium"
 export NID="172.22.160.0/24"
 export NGW="172.22.160.254"
 # Container runtime：crio（預設）或 containerd
-export K8SCRI="crio"
+export K8SCRI="${K8SCRI:-crio}"
 # 節點 image：自 GHCR 拉取；離線或該版本未發佈時 kcn 會以同名配方本地建置
 export IMG="ghcr.io/tarokolabs/tk8s/node/${K8SCRI}:v${KVER}"
 export LCTN="172.22.160.1:tdcs1-control-plane:4G:4 \

--- a/conf/tk8s.conf
+++ b/conf/tk8s.conf
@@ -8,7 +8,7 @@ export K8SCNI="cilium"
 export NID="172.22.0.0/24"
 export NGW="172.22.0.254"
 # Container runtime：crio（預設）或 containerd
-export K8SCRI="crio"
+export K8SCRI="${K8SCRI:-crio}"
 # 節點 image：自 GHCR 拉取；離線或該版本未發佈時 kcn 會以同名配方本地建置
 export IMG="ghcr.io/tarokolabs/tk8s/node/${K8SCRI}:v${KVER}"
 export LCTN="172.22.0.1:tk8s-control-plane:3G:2 \

--- a/conf/tkbp.conf
+++ b/conf/tkbp.conf
@@ -8,7 +8,7 @@ export K8SCNI="cilium"
 export NID="172.22.8.0/24"
 export NGW="172.22.8.254"
 # Container runtime：crio（預設）或 containerd
-export K8SCRI="crio"
+export K8SCRI="${K8SCRI:-crio}"
 # 節點 image：自 GHCR 拉取；離線或該版本未發佈時 kcn 會以同名配方本地建置
 export IMG="ghcr.io/tarokolabs/tk8s/node/${K8SCRI}:v${KVER}"
 export LCTN="172.22.8.1:tkbp-control-plane:4G:4 \

--- a/conf/tkdev.conf
+++ b/conf/tkdev.conf
@@ -8,7 +8,7 @@ export K8SCNI="cilium"
 export NID="172.22.32.0/24"
 export NGW="172.22.32.254"
 # Container runtime：crio（預設）或 containerd
-export K8SCRI="crio"
+export K8SCRI="${K8SCRI:-crio}"
 # 節點 image：自 GHCR 拉取；離線或該版本未發佈時 kcn 會以同名配方本地建置
 export IMG="ghcr.io/tarokolabs/tk8s/node/${K8SCRI}:v${KVER}"
 

--- a/conf/tkdt.conf
+++ b/conf/tkdt.conf
@@ -8,7 +8,7 @@ export K8SCNI="cilium"
 export NID="172.22.16.0/24"
 export NGW="172.22.16.254"
 # Container runtime：crio（預設）或 containerd
-export K8SCRI="crio"
+export K8SCRI="${K8SCRI:-crio}"
 # 節點 image：自 GHCR 拉取；離線或該版本未發佈時 kcn 會以同名配方本地建置
 export IMG="ghcr.io/tarokolabs/tk8s/node/${K8SCRI}:v${KVER}"
 export LCTN="172.22.16.1:tkdt-control-plane:4G:4 \

--- a/conf/tkha.conf
+++ b/conf/tkha.conf
@@ -8,7 +8,7 @@ export K8SCNI="cilium"
 export NID="172.22.64.0/24"
 export NGW="172.22.64.254"
 # Container runtime：crio（預設）或 containerd
-export K8SCRI="crio"
+export K8SCRI="${K8SCRI:-crio}"
 # 節點 image：自 GHCR 拉取；離線或該版本未發佈時 kcn 會以同名配方本地建置
 export IMG="ghcr.io/tarokolabs/tk8s/node/${K8SCRI}:v${KVER}"
 export LCTN="172.22.64.1:tkha-control-plane:4G:4 \

--- a/conf/tklh.conf
+++ b/conf/tklh.conf
@@ -8,7 +8,7 @@ export K8SCNI="cilium"
 export NID="172.22.16.0/24"
 export NGW="172.22.16.254"
 # Container runtime：crio（預設）或 containerd
-export K8SCRI="crio"
+export K8SCRI="${K8SCRI:-crio}"
 # 節點 image：自 GHCR 拉取；離線或該版本未發佈時 kcn 會以同名配方本地建置
 export IMG="ghcr.io/tarokolabs/tk8s/node/${K8SCRI}:v${KVER}"
 export LCTN="172.22.16.1:tklh-control-plane:6G:4 \

--- a/conf/tkops.conf
+++ b/conf/tkops.conf
@@ -8,7 +8,7 @@ export K8SCNI="cilium"
 export NID="172.22.24.0/24"
 export NGW="172.22.24.254"
 # Container runtime：crio（預設）或 containerd
-export K8SCRI="crio"
+export K8SCRI="${K8SCRI:-crio}"
 # 節點 image：自 GHCR 拉取；離線或該版本未發佈時 kcn 會以同名配方本地建置
 export IMG="ghcr.io/tarokolabs/tk8s/node/${K8SCRI}:v${KVER}"
 


### PR DESCRIPTION
#45 後補驗 containerd 路徑時發現：conf 無條件 `export K8SCRI="crio"` 蓋掉外部值，`K8SCRI=containerd` 無效、切 runtime 必須改檔——與 `KVER` 的覆寫模式不一致。改 `${K8SCRI:-crio}`（預設不變）。containerd 路徑 E2E 以此為前提重跑，結果隨後補到本 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)